### PR TITLE
Add ability to define and load custom routes when prelaunch is enabled.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,6 +46,9 @@ the following options:
 * `campaign_monitor_api_key` and `campaign_monitor_list_id` (optional) -
   Add your Campaign Monitor API key and list ID to have new subscribers
   automatically added. 
+* `custom_routes_file` (optional, defaults to `config/prelaunch_routes.rb` - Specify your own custom routes 
+  file to use when T-Minus is enabled. The file should be configured just like a normal routes.rb. If you don't
+  specify a custom file, the default file `config/prelaunch_routes.rb` is tried.
 
 Having trouble finding your Campaign Monitor API key or list ID? Visit
 [this page](http://www.campaignmonitor.com/api/required/).
@@ -59,6 +62,16 @@ changes to the generated files:
     rails generate t_minus:controller
 
     rails generate t_minus:model
+
+
+## Customising your routes
+
+If you want to add additional routes for different controllers, you can now add 
+those routes to config/prelaunch_routes.rb using the standard syntax. You can generate a
+template prelaunch_routes.rb file with:
+
+    rails generate t_minus:routes
+
 
 ## Contributing to T-Minus
 

--- a/config/initializers/load_prelaunch_config.rb
+++ b/config/initializers/load_prelaunch_config.rb
@@ -8,3 +8,10 @@ if File.exists?(prelaunch_config_path)
 else
   PRELAUNCH_CONFIG = {}
 end
+
+prelaunch_custom_routes_file = PRELAUNCH_CONFIG[:custom_routes_file] || "#{Rails.root}/config/prelaunch_routes.rb"
+if File.exists?(prelaunch_custom_routes_file)
+  PRELAUNCH_CUSTOM_ROUTES = File.read(prelaunch_custom_routes_file)
+else
+  PRELAUNCH_CUSTOM_ROUTES = ""
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 module TMinus
   module Routes
     def Routes.map
-      Rails.application.routes.draw do
+      Rails.application.routes.draw { eval(PRELAUNCH_CUSTOM_ROUTES) }
+      Rails.application.routes.draw do        
         post '/' => 'prelaunch#create', :as => :prelaunch
         root :to => 'prelaunch#new'
       end


### PR DESCRIPTION
Hi I've put an implementation together for johngrimes/t-minus#2 which is working for me. I'mm not very good with tests so I'm still working on that side of things but wanted to get your opinion on the methodology before I proceed.

Also I'm having problems running the cucumber tests in your project. Could you clarify which versions of cucumber and deps you are using for this project?

Thanks
## 

By default we look for config/prelaunch_routes.rb but this can be
customised in config/prelaunch_config.yml with the custom_routes_file
key.

template generator gives example of using key in the
prelaunch_config.yml and an empty prelaunch_routes.rb is created for
reference.
