### PR TITLE
Updates for Rails 3.2.3 and CreateSend 1.0.3

### DIFF
--- a/app/models/prelaunch_subscriber.rb
+++ b/app/models/prelaunch_subscriber.rb
@@ -7,6 +7,8 @@ class PrelaunchSubscriber < ActiveRecord::Base
 
   after_save :add_to_campaign_monitor, :if => :campaign_monitor_configured?
 
+  attr_accessible :email
+
   private
 
   def add_to_campaign_monitor

--- a/t-minus.gemspec
+++ b/t-minus.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['{spec}/**/*']
   s.required_rubygems_version = Gem::Requirement.new('>= 1.3.6') if s.respond_to? :required_rubygems_version=
 
-  s.add_dependency 'createsend', '~> 0.2'
+  s.add_dependency 'createsend', '~> 1'
 
   s.add_development_dependency 'bundler', '~> 1'
   s.add_development_dependency 'rspec-rails', '~> 2'


### PR DESCRIPTION
In Rails 3.2.3, the ActiveRecord whitelist_attributes is true. Rather than turning this off and losing the added security, I updated the prelaunch_subscriber model so that the email attribute can be mass assigned. Without this update, you will receive a mass assignment exception. Secondly, the old version of the CreateSend gem (~0.2) emits a MultiJSON parse error; upgrading to a version of CreateSend of at least 1.0.0 fixes this issue.

This is my first pull request so apologies if I've done it all wrong! I could not get the tests to run on my environment so I was not able to update them. Please let me know if there's things I could have done better for future reference. Thanks for all your work on this gem, it's made our lives a lot easier! 
